### PR TITLE
Remove commas from amounts to support amounts larger than 1000

### DIFF
--- a/src/Santander.py
+++ b/src/Santander.py
@@ -25,7 +25,7 @@ class Transaction:
     money_amount = cols[2] or cols[3]
     assert money_amount[0] == u'\xa3'
     self.amount_str = money_amount[1:]
-    self.amount = float(money_amount[1:])
+    self.amount = float(money_amount[1:].replace(',', ''))
     if cols[3]:
       self.amount = -self.amount
 


### PR DESCRIPTION
Amounts larger thant1000 raise an error since they contain a comma and are not properly converted by "float()". This problem might appear only for some locales.
This removes commas from fetched amounts.
